### PR TITLE
Avoid Dommy throwing on same node

### DIFF
--- a/src/dommy.js
+++ b/src/dommy.js
@@ -42,6 +42,7 @@ class Dommy {
   insertBefore(newNode, liveNode) {
     if (!liveNode) liveNode = this.lastElementChild;
     this.operations.push(`insertBefore(${newNode.value}, ${liveNode.value})`);
+    if (newNode === liveNode) return;
     this._removeChild(newNode);
     const index = this._childNodes.indexOf(liveNode);
     if (index < 0)


### PR DESCRIPTION
The `insertBefore` operation doesn't throw on the real DOM, so it shouldn't here as well.

Basically, if the node is the same, for whatever reason, the Dommy throws an error, which shouldn't, but it also shouldn't remove the node from its index, as no change happens whatsoever, and it ends up in the broken path.

This might also solve the _snabdom_ failing with shuffled nodes, but I haven't tested.