### PR TITLE
Update udomdiff to its latest

### DIFF
--- a/libs/udomdiff.js
+++ b/libs/udomdiff.js
@@ -66,23 +66,8 @@ module.exports = (parentNode, a, b, get, before) => {
       aEnd--;
       bEnd--;
     }
-    // single last swap: fast path
-    else if ((aEnd - aStart) === 1 && (bEnd - bStart) === 1) {
-      // we could be in a situation where the node was either unknown,
-      // be at the end of the future nodes list, or be in the middle
-      if (map && map.has(a[aStart])) {
-        // in the end or middle case, find out where to insert it
-        parentNode.insertBefore(
-          get(b[bStart], 1),
-          get(bEnd < bLength ? b[bEnd] : before, 0)
-        );
-      }
-      // if the node is unknown, just replace it with the new one
-      else
-        parentNode.replaceChild(get(b[bStart], 1), get(a[aStart], -1));
-      aStart++;
-      bStart++;
-    }
+    // The once here single last swap "fast path" has been removed in v1.1.0
+    // https://github.com/WebReflection/udomdiff/blob/single-final-swap/esm/index.js#L69-L85
     // reverse swap: also fast path
     else if (
       a[aStart] === b[bEnd - 1] &&


### PR DESCRIPTION
Also thanks to this benchmark, I've realized that optimizing for the final single swap is not really worth the size, and since I've claimed for _udomdiff_ to be the smallest standalone differ out there, I want its size to be competitive with other libraries in here, even if others are not really standalone projects that work out of the box with the DOM.

It'd be great to update both size and performance in the README, even if I'm not expecting much changes in terms of perf (it could be slightly worse, but being around 420 bytes instead of 460 feels right).