### PR TITLE
Make the benchmark more focused on the diffing part

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Simple benchmark for testing your DOM diffing algorithm.
 
 | Position | Library | Size | Speed |
 | --- | --- | --- | --- |
-| 🏆 1 | [udomdiff](https://github.com/WebReflection/udomdiff) | 424B | ~264ms |
-| 2 | [snabbdom](https://github.com/snabbdom/snabbdom) | 431B | ~265ms |
-| 3 | [spect](https://github.com/spectjs/spect) | 299B | ~267ms |
-| 4 | [list-difference](https://github.com/paldepind/list-difference/) | 283B | ~311ms |
-| 5 | [stage0](https://github.com/Freak613/stage0) | 950B | ~358ms |
-| 6 | [heckel](https://johnresig.com/projects/javascript-diff-algorithm/) | 450B | ~499ms |
+| 🏆 1 | [udomdiff](https://github.com/WebReflection/udomdiff) | 397B | ~264ms |
+| 2 | [snabbdom](https://github.com/snabbdom/snabbdom) | 412B | ~265ms |
+| 3 | [spect](https://github.com/spectjs/spect) | 297B | ~267ms |
+| 4 | [list-difference](https://github.com/paldepind/list-difference/) | 271B | ~311ms |
+| 5 | [stage0](https://github.com/Freak613/stage0) | 941B | ~358ms |
+| 6 | [heckel](https://johnresig.com/projects/javascript-diff-algorithm/) | 449B | ~499ms |
 
 ---
 

--- a/libs/heckel.js
+++ b/libs/heckel.js
@@ -8,7 +8,7 @@
  * More Info:
  *  http://ejohn.org/projects/javascript-diff-algorithm/
  */
-module.exports = function(parent, o, n, get, before) {
+module.exports = function(parent, o, n, before) {
   var out = diff(o, n);
 
   if (out.n.length == 0) {

--- a/libs/list-difference.js
+++ b/libs/list-difference.js
@@ -1,5 +1,5 @@
 // a is old list, b is the new
-module.exports = function(parent, a, b, get, before) {
+module.exports = function(parent, a, b, before) {
   const aIdx = new Map();
   const bIdx = new Map();
   let i;
@@ -22,11 +22,11 @@ module.exports = function(parent, a, b, get, before) {
       i++;
     } else if (b.length <= j) {
       // No more elements in new, this is a delete
-      parent.removeChild(get(a[i], -1));
+      parent.removeChild(a[i]);
       i++;
     } else if (a.length <= i) {
       // No more elements in old, this is an addition
-      parent.insertBefore(get(bElm, 1), get(a[i], 0) || before);
+      parent.insertBefore(bElm, a[i] || before);
       j++;
     } else if (aElm === bElm) {
       // No difference, we move on
@@ -40,20 +40,20 @@ module.exports = function(parent, a, b, get, before) {
       var wantedElmInOld = aIdx.get(bElm);
       if (curElmInNew === undefined) {
         // Current element is not in new list, it has been removed
-        parent.removeChild(get(a[i], -1));
+        parent.removeChild(a[i]);
         i++;
       } else if (wantedElmInOld === undefined) {
         // New element is not in old list, it has been added
         parent.insertBefore(
-          get(bElm, 1),
-          get(a[i], 0) || before
+          bElm,
+          a[i] || before
         );
         j++;
       } else {
         // Element is in both lists, it has been moved
         parent.insertBefore(
-          get(a[wantedElmInOld], 1),
-          get(a[i], 0) || before
+          a[wantedElmInOld],
+          a[i] || before
         );
         a[wantedElmInOld] = null;
         j++;

--- a/libs/snabbdom.js
+++ b/libs/snabbdom.js
@@ -1,5 +1,5 @@
 // a is old list, b is the new
-module.exports = function(parent, a, b, get, afterNode) {
+module.exports = function(parent, a, b, afterNode) {
   const a_index = new Map();
   const b_index = new Map();
 
@@ -33,15 +33,15 @@ module.exports = function(parent, a, b, get, afterNode) {
     }
     else if (start_a === end_b) {
       parent.insertBefore(
-        get(a[start_i], 1),
-        get(a[end_i], -0).nextSibling || afterNode
+        a[start_i],
+        a[end_i].nextSibling || afterNode
       );
       start_a = a[++start_i];
       end_b = b[--end_j];
     } else if (end_a === start_b) {
       parent.insertBefore(
-        get(a[end_i], 1),
-        get(a[start_i] || afterNode, 0)
+        a[end_i],
+        a[start_i] || afterNode
       );
       end_a = a[--end_i];
       start_b = b[++start_j];
@@ -73,8 +73,8 @@ module.exports = function(parent, a, b, get, afterNode) {
       // because it doesn't recursively diff and patch the replaced node.
       if (old_start_j === undefined && new_start_i === undefined) {
         parent.replaceChild(
-          get(start_b, 1),
-          get(a[start_i], -1) // old
+          start_b,
+          a[start_i] // old
         );
         start_a = a[++start_i];
         start_b = b[++start_j];
@@ -82,21 +82,21 @@ module.exports = function(parent, a, b, get, afterNode) {
       // Insertion
       else if (old_start_j === undefined) {
         parent.insertBefore(
-          get(start_b, 1),
-          get(a[start_i] || afterNode, 0)
+          start_b,
+          a[start_i] || afterNode
         );
         start_b = b[++start_j];
       }
       // Deletion
       else if (new_start_i === undefined) {
-        parent.removeChild(get(start_a, -1));
+        parent.removeChild(start_a);
         start_a = a[++start_i];
       }
       // Move
       else {
         parent.insertBefore(
-          get(start_b, 1),
-          get(a[start_i] || afterNode, 0)
+          start_b,
+          a[start_i] || afterNode
         );
         a[old_start_j] = null;
         start_b = b[++start_j];
@@ -106,11 +106,11 @@ module.exports = function(parent, a, b, get, afterNode) {
   if (start_i <= end_i || start_j <= end_j) {
     if (start_i > end_i) { // old list exhausted; process new list additions
       for (start_j; start_j <= end_j; start_b = b[++start_j]) {
-        parent.insertBefore(get(start_b, 1), get(afterNode, 0));
+        parent.insertBefore(start_b, afterNode);
       }
     } else { // new list exhausted; process old list removals
       for (start_i; start_i <= end_i; ++start_i) {
-        parent.removeChild(get(a[start_i], -1));
+        parent.removeChild(a[start_i]);
       }
     }
   }

--- a/libs/spect.js
+++ b/libs/spect.js
@@ -1,4 +1,4 @@
-module.exports = function diff(parent, a, b, get, before) {
+module.exports = function diff(parent, a, b, before) {
   const bmap = new Map(),
     amap = new Map(),
     nextSibling = Array(a.length);

--- a/libs/stage0.js
+++ b/libs/stage0.js
@@ -13,7 +13,6 @@ module.exports = function reconcile(
   parent,
   renderedValues,
   data,
-  createFn,
   afterNode,
   beforeNode
 ) {
@@ -38,7 +37,7 @@ module.exports = function reconcile(
     let node,
       mode = afterNode !== undefined ? 1 : 0;
     for (let i = 0, len = data.length; i < len; i++) {
-      node = createFn(data[i]);
+      node = data[i];
       mode ? parent.insertBefore(node, afterNode) : parent.appendChild(node);
     }
     return data;
@@ -136,7 +135,7 @@ module.exports = function reconcile(
       let node,
         mode = afterNode ? 1 : 0;
       while (newStart <= newEnd) {
-        node = createFn(data[newStart]);
+        node = data[newStart];
         mode ? parent.insertBefore(node, afterNode) : parent.appendChild(node);
         newStart++;
       }
@@ -181,7 +180,7 @@ module.exports = function reconcile(
 
     let mode = afterNode ? 1 : 0;
     for (let i = newStart; i <= newEnd; i++) {
-      node = createFn(data[i]);
+      node = data[i];
       mode ? parent.insertBefore(node, afterNode) : parent.appendChild(node);
     }
 
@@ -210,7 +209,7 @@ module.exports = function reconcile(
       lisIdx--;
     } else {
       if (P[i] === -1) {
-        tmpD = createFn(data[i]);
+        tmpD = data[i];
       } else {
         tmpD = nodes[P[i]];
       }

--- a/libs/udomdiff.js
+++ b/libs/udomdiff.js
@@ -25,7 +25,7 @@
  * @param {Node} [before] The optional node used as anchor to insert before.
  * @returns {Node[]} The same list of future children.
  */
-module.exports = (parentNode, a, b, get, before) => {
+module.exports = (parentNode, a, b, before) => {
   const bLength = b.length;
   let aEnd = a.length;
   let bEnd = bLength;
@@ -41,18 +41,18 @@ module.exports = (parentNode, a, b, get, before) => {
       // must be retrieved, otherwise it's gonna be the first item.
       const node = bEnd < bLength ?
         (bStart ?
-          (get(b[bStart - 1], -0).nextSibling) :
-          get(b[bEnd - bStart], 0)) :
+          (b[bStart - 1].nextSibling) :
+          b[bEnd - bStart]) :
         before;
       while (bStart < bEnd)
-        parentNode.insertBefore(get(b[bStart++], 1), node);
+        parentNode.insertBefore(b[bStart++], node);
     }
     // remove head or tail: fast path
     else if (bEnd === bStart) {
       while (aStart < aEnd) {
         // remove the node only if it's unknown or not live
         if (!map || !map.has(a[aStart]))
-          parentNode.removeChild(get(a[aStart], -1));
+          parentNode.removeChild(a[aStart]);
         aStart++;
       }
     }
@@ -79,12 +79,12 @@ module.exports = (parentNode, a, b, get, before) => {
       // or asymmetric too
       // [1, 2, 3, 4, 5]
       // [1, 2, 3, 5, 6, 4]
-      const node = get(a[--aEnd], -1).nextSibling;
+      const node = a[--aEnd].nextSibling;
       parentNode.insertBefore(
-        get(b[bStart++], 1),
-        get(a[aStart++], -1).nextSibling
+        b[bStart++],
+        a[aStart++].nextSibling
       );
-      parentNode.insertBefore(get(b[--bEnd], 1), node);
+      parentNode.insertBefore(b[--bEnd], node);
       // mark the future index as identical (yeah, it's dirty, but cheap 👍)
       // The main reason to do this, is that when a[aEnd] will be reached,
       // the loop will likely be on the fast path, as identical to b[bEnd].
@@ -128,17 +128,17 @@ module.exports = (parentNode, a, b, get, before) => {
           // this would place 7 before 1 and, from that time on, 1, 2, and 3
           // will be processed at zero cost
           if (sequence > (index - bStart)) {
-            const node = get(a[aStart], 0);
+            const node = a[aStart];
             while (bStart < index)
-              parentNode.insertBefore(get(b[bStart++], 1), node);
+              parentNode.insertBefore(b[bStart++], node);
           }
           // if the effort wasn't good enough, fallback to a replace,
           // moving both source and target indexes forward, hoping that some
           // similar node will be found later on, to go back to the fast path
           else {
             parentNode.replaceChild(
-              get(b[bStart++], 1),
-              get(a[aStart++], -1)
+              b[bStart++],
+              a[aStart++]
             );
           }
         }
@@ -150,7 +150,7 @@ module.exports = (parentNode, a, b, get, before) => {
       // to remove it, and check the next live node out instead, meaning
       // that only the live list index should be forwarded
       else
-        parentNode.removeChild(get(a[aStart++], -1));
+        parentNode.removeChild(a[aStart++]);
     }
   }
   return b;

--- a/src/bench.js
+++ b/src/bench.js
@@ -3,7 +3,7 @@ const c = require('ansi-colors');
 var Terser = require('terser');
 const gzipSize = require('gzip-size');
 
-const {Dommy, Nody, get} = require('./dommy.js');
+const {Dommy, Nody} = require('./dommy.js');
 
 let parent = new Dommy();
 
@@ -216,7 +216,6 @@ function random(parent, diff) {
     parent,
     parent.childNodes,
     Array.from(parent.childNodes).sort(() => Math.random() - Math.random()),
-    get,
     parent.lastElementChild
   );
 }
@@ -226,7 +225,6 @@ function reverse(parent, diff) {
     parent,
     parent.childNodes,
     Array.from(parent.childNodes).reverse(),
-    get,
     parent.lastElementChild
   );
 }
@@ -240,7 +238,6 @@ function append1000(parent, diff) {
     parent,
     parent.childNodes,
     childNodes,
-    get,
     parent.lastElementChild
   );
 }
@@ -250,7 +247,6 @@ function clear(parent, diff) {
     parent,
     parent.childNodes,
     [],
-    get,
     parent.lastElementChild
   );
 }
@@ -264,7 +260,6 @@ function create1000(parent, diff) {
     parent,
     parent.childNodes,
     childNodes,
-    get,
     parent.lastElementChild
   );
 }
@@ -277,7 +272,6 @@ function create10000(parent, diff) {
     parent,
     parent.childNodes,
     childNodes,
-    get,
     parent.lastElementChild
   );
 }
@@ -291,7 +285,6 @@ function swapRows(parent, diff) {
     parent,
     parent.childNodes,
     childNodes,
-    get,
     parent.lastElementChild
   );
 }
@@ -304,7 +297,6 @@ function updateEach10thRow(parent, diff) {
     parent,
     parent.childNodes,
     childNodes,
-    get,
     parent.lastElementChild
   );
 }

--- a/src/dommy.js
+++ b/src/dommy.js
@@ -101,4 +101,4 @@ class Nody {
   }
 }
 
-module.exports = {Dommy, Nody, get: o => o};
+module.exports = {Dommy, Nody};


### PR DESCRIPTION
The _udomdiff_ `get(node, operation)` has no meaning in here, but it also has no meaning for most other libraries, as the `get` is currently a _no-op_.
The operation is also not always reflected elsewhere, and there are libraries not using the `get(node)` at all, or using a `createFn` instead, which is not what `get` is about, in _udomdiff_.
Accordingly, `get` could penalize both size and performance, so I've decided to remove it completely from the equation, making the benchmark more fair across implementations.