### PR TITLE
Fixed nextSibling typo

### DIFF
--- a/src/dommy.js
+++ b/src/dommy.js
@@ -33,7 +33,7 @@ class Siblings {
     if (parentNode) {
       const {childNodes} = parentNode;
       const i = childNodes.indexOf(this) + 1;
-      if (-1 < i && i < childNodes.length)
+      if (0 < i && i < childNodes.length)
         return childNodes[i];
     }
     return null;


### PR DESCRIPTION
Apologies I've written a typo in the `nextSibling` method. Not a big deal (it works anyway) but it should be fixed whenever you have time.

Thanks.