### PR TITLE
Improve operations count to reflect real world DOM mutations

### DIFF
--- a/src/bench.js
+++ b/src/bench.js
@@ -171,7 +171,7 @@ libs.forEach((lib) => {
 
   start();
   childNodes = create1000(parent, diff, childNodes);
-  stop(parent.operations.length, 1000);
+  stop(parent.mutations.length, 1000);
   console.assert(
     verifyNodes(parent, childNodes, 1000),
     '%s 1k',
@@ -180,7 +180,7 @@ libs.forEach((lib) => {
 
   start();
   childNodes = create1000(parent, diff, childNodes);
-  stop(parent.operations.length, 2000);
+  stop(parent.mutations.length, 2000);
   console.assert(
     verifyNodes(parent, childNodes, 1000),
     '%s replace',
@@ -189,7 +189,7 @@ libs.forEach((lib) => {
 
   start();
   childNodes = random(parent, diff, childNodes);
-  stop(parent.operations.length, 1000);
+  stop(parent.mutations.length, 2000);
   console.assert(
     verifyNodes(parent, childNodes, 1000),
     '%s random',
@@ -198,7 +198,7 @@ libs.forEach((lib) => {
 
   start();
   childNodes = reverse(parent, diff, childNodes);
-  stop(parent.operations.length, 1000);
+  stop(parent.mutations.length, 2000);
   console.assert(
     verifyNodes(parent, childNodes, 1000),
     '%s reverse',
@@ -207,7 +207,7 @@ libs.forEach((lib) => {
 
   start();
   childNodes = clear(parent, diff, childNodes);
-  stop(parent.operations.length, 1000);
+  stop(parent.mutations.length, 1000);
   console.assert(
     verifyNodes(parent, childNodes, 0),
     '%s clear',
@@ -218,7 +218,7 @@ libs.forEach((lib) => {
 
   start();
   childNodes = append1000(parent, diff, childNodes);
-  stop(parent.operations.length, 2000);
+  stop(parent.mutations.length, 2000);
   console.assert(
     verifyNodes(parent, childNodes, 2000),
     '%s append 1k',
@@ -227,7 +227,7 @@ libs.forEach((lib) => {
 
   start();
   childNodes = prepend1000(parent, diff, childNodes);
-  stop(parent.operations.length, 1000);
+  stop(parent.mutations.length, 1000);
   console.assert(
     verifyNodes(parent, childNodes, 3000),
     '%s prepend 1k',
@@ -239,7 +239,7 @@ libs.forEach((lib) => {
 
   start();
   childNodes = swapRows(parent, diff, childNodes);
-  stop(parent.operations.length, 2);
+  stop(parent.mutations.length, 4);
   console.assert(
     parent.childNodes[1].textContent == 998 &&
     parent.childNodes[998].textContent == 1 &&
@@ -250,7 +250,7 @@ libs.forEach((lib) => {
 
   start();
   childNodes = updateEach10thRow(parent, diff, childNodes);
-  stop(parent.operations.length, 200);
+  stop(parent.mutations.length, 200);
   console.assert(
     verifyNodes(parent, childNodes, 1000),
     '%s update 10th',
@@ -261,7 +261,7 @@ libs.forEach((lib) => {
 
   start();
   childNodes = create10000(parent, diff, childNodes);
-  stop(parent.operations.length, 10000);
+  stop(parent.mutations.length, 10000);
   console.assert(
     verifyNodes(parent, childNodes, 10000),
     '%s 10k',
@@ -270,7 +270,7 @@ libs.forEach((lib) => {
 
   start();
   childNodes = swapRows(parent, diff, childNodes);
-  stop(parent.operations.length, 2);
+  stop(parent.mutations.length, 4);
   console.assert(
     parent.childNodes[1].textContent == 9998 &&
     parent.childNodes[9998].textContent == 1 &&
@@ -317,36 +317,41 @@ function instrument(parent) {
     removeChild,
     replaceChild
   } = parent;
-  parent.operations = [];
+  parent.mutations = [];
   parent.appendChild = function (newNode) {
-    this.operations.push(`appendChild(${newNode.textContent})`);
+    const {textContent} = newNode;
+    if (newNode.parentNode)
+      this.mutations.push(`append: drop(${textContent})`);
+    this.mutations.push(`append: add(${textContent})`);
     return appendChild.call(this, newNode);
   };
   parent.insertBefore = function (newNode, oldNode) {
-    this.operations.push(
+    const {textContent} = newNode;
+    if (newNode.parentNode)
+      this.mutations.push(`insert: drop(${textContent})`);
+    this.mutations.push(
       oldNode ?
-        `insertBefore(${newNode.textContent}, ${oldNode.textContent})` :
-        `insertBefore(${newNode.textContent})`
+        `insert: put(${textContent}) before (${oldNode.textContent})` :
+        `insert: add(${textContent})`
     );
     return insertBefore.call(this, newNode, oldNode);
   };
   parent.removeChild = function (oldNode) {
-    this.operations.push(`removeChild(${oldNode.textContent})`);
+    this.mutations.push(`remove: drop(${oldNode.textContent})`);
     return removeChild.call(this, oldNode);
   };
   parent.replaceChild = function (newNode, oldNode) {
-    this.operations.push(
-      `delete#replaceChild(${newNode.textContent}, ${oldNode.textContent})`
-    );
-    this.operations.push(
-      `insert#replaceChild(${newNode.textContent}, ${oldNode.textContent})`
-    );
+    const {textContent} = newNode;
+    this.mutations.push(`replace: drop(${oldNode.textContent})`);
+    if (newNode.parentNode)
+      this.mutations.push(`replace: drop(${textContent})`);
+    this.mutations.push(`replace: put(${textContent})`);
     return replaceChild.call(this, newNode, oldNode);
   };
 }
 
 function reset(parent) {
-  parent.operations.splice(0);
+  parent.mutations.splice(0);
 }
 
 function round(num) {


### PR DESCRIPTION
As discussed in https://github.com/luwes/js-diff-benchmark/issues/7#issuecomment-615875584, the way we are counting operations does not reflect the real-wolrd amount of DOM mutations triggered through the nodes:

  * `appendChild` is 1 up to 2 mutations, if the node was already live (moved)
  * `insertBefore` is 1 up to 2 mutations, if the node was already live (moved)
  * `removeChild` is always only 1 mutation
  * `replaceChild` is 2, up to 3 mutations if the node was already live (moved)

Accordingly, the counting should change too, specially the swap and the shuffle, as most libraries technically trigger similar amount of observable mutations on the tree:

  * the swap consist in 4 mutations, 2 _disconnect_ followed by 2 _connect_
  * the shuffle consist in either `removeChild` followed by an `insertBefore`, which sum is 2, or `replaceChild` which counts as either 2 or 3

The table better reasons, and explain, why _udomdiff_ performs similarly, if not faster, than other libraries when it comes to the shuffling example

![Screenshot from 2020-04-18 16-11-51](https://user-images.githubusercontent.com/85749/79640215-a1ea9300-8190-11ea-9a8b-54a77d9bcee5.png)
