### PR TITLE
Add spect forward implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Simple benchmark for testing your DOM diffing algorithm.
 | 🏆 1 | [udomdiff](https://github.com/WebReflection/udomdiff) | 397B | ~248ms |
 | 2 | [snabbdom](https://github.com/snabbdom/snabbdom) | 412B | ~253ms |
 | 3 | [list-difference](https://github.com/paldepind/list-difference/) | 281B | ~258ms |
-| 4 | [spect](https://github.com/spectjs/spect) | 297B | ~269ms |
+| 4 | [spect](https://github.com/spectjs/spect) | 218B | ~269ms |
 | 5 | [stage0](https://github.com/Freak613/stage0) | 941B | ~326ms |
 | 6 | [heckel](https://johnresig.com/projects/javascript-diff-algorithm/) | 449B | ~481ms |
 

--- a/libs/spect.js
+++ b/libs/spect.js
@@ -1,35 +1,28 @@
-module.exports = function merge (parent, a, b, before) {
-  let i, ai, bi, off, bidx = new Set(b), aidx = new Set(a)
+module.exports = function merge (parent, a, b) {
+  let i, j, ai, bj, bprevNext = a[0], bidx = new Set(b), aidx = new Set(a)
 
-  // walk by b from tail
-  // a: 1 2 3 4 5, b: 1 2 3 → off: +2
-  // ~i-- === i-- >= 0
-  for (i = b.length, off = a.length - i; ~i--; ) {
-    ai = a[i + off], bi = b[i]
+  for (i = 0, j = 0; j <= b.length; i++, j++) {
+    ai = a[i], bj = b[j]
 
-    if (ai === bi) {}
+    if (ai === bj) {}
 
     else if (ai && !bidx.has(ai)) {
-      // replace (bi can be undefined in case of clearing the list)
-      if (bi && !aidx.has(bi)) parent.replaceChild(bi, ai)
+      // replace
+      if (bj && !aidx.has(bj)) parent.replaceChild(bj, ai)
 
       // remove
-      else (parent.removeChild(ai), off--, i++)
+      else (parent.removeChild(ai), j--)
+    }
+    else if (bj) {
+      // move - skips bj for the following swap
+      if (!aidx.has(bj)) i--
+
+      // insert after bj-1, bj
+      parent.insertBefore(bj, bprevNext)
     }
 
-    else if (bi) {
-      if (bi.nextSibling != before || !bi.nextSibling) {
-        // move (skip since will be handled by the following b)
-        if (bidx.has(ai)) off--
-
-        // insert
-        parent.insertBefore(bi, before), off++
-      }
-    }
-
-    before = bi
+    bprevNext = bj && bj.nextSibling
   }
 
   return b
 }
-


### PR DESCRIPTION
Ok, this adds forward spect implementation, 218b.

It is the slowest among others (due to create/append metrics slowdown), but the reason is, I suspect, suboptimal Dommy `nextSibling` implementation.
The real DOM demonstrates digits, comparable with direct appendChild:
![image](https://user-images.githubusercontent.com/300067/79640222-620ab800-815e-11ea-8f2c-fbfb254f314f.png).
(another possible reason - some intrinsic v8 optimizations for some algos - not going to chase that way))