### PR TITLE
Relative spect impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Simple benchmark for testing your DOM diffing algorithm.
 | 4 | [snabbdom](https://github.com/snabbdom/snabbdom) | 412B | ~21ms |
 | 3 | [heckel](https://johnresig.com/projects/javascript-diff-algorithm/) | 449B | ~37ms |
 | 5 | [stage0](https://github.com/Freak613/stage0) | 941B | ~47ms |
-| 6 | [spect](https://github.com/spectjs/spect) | 218B | ~68ms |
+| 6 | [spect](https://github.com/spectjs/spect) | 209B (min 185b) | ~28ms |
 
 ## Screenshot
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Simple benchmark for testing your DOM diffing algorithm.
 | --- | --- | --- | --- |
 | 🏆 1 | [udomdiff](https://github.com/WebReflection/udomdiff) | 397B | ~18ms |
 | 2 | [list-difference](https://github.com/paldepind/list-difference/) | 281B | ~21ms |
-| 4 | [snabbdom](https://github.com/snabbdom/snabbdom) | 412B | ~21ms |
-| 3 | [heckel](https://johnresig.com/projects/javascript-diff-algorithm/) | 449B | ~37ms |
-| 5 | [stage0](https://github.com/Freak613/stage0) | 941B | ~47ms |
-| 6 | [spect](https://github.com/spectjs/spect) | 209B (min 185b) | ~28ms |
+| 3 | [snabbdom](https://github.com/snabbdom/snabbdom) | 412B | ~21ms |
+| 4 | [spect](https://github.com/spectjs/spect) | 209B (min 185b) | ~28ms |
+| 5 | [heckel](https://johnresig.com/projects/javascript-diff-algorithm/) | 449B | ~37ms |
+| 6 | [stage0](https://github.com/Freak613/stage0) | 941B | ~47ms |
 
 ## Screenshot
 

--- a/libs/spect.js
+++ b/libs/spect.js
@@ -1,27 +1,27 @@
 module.exports = function merge (parent, a, b) {
-  let i, j, ai, bj, bprevNext = a[0], bidx = new Set(b), aidx = new Set(a)
+  const bidx = new Set(b), aidx = new Set(a)
+  let i, cur = a[0], next, bi
 
-  for (i = 0, j = 0; j <= b.length; i++, j++) {
-    ai = a[i], bj = b[j]
+  for (i = 0; i <= b.length; i++) {
+    bi = b[i]
+    next = cur && cur.nextSibling
 
-    if (ai === bj) {}
+    // skip
+    if (cur === bi) cur = next
 
-    else if (ai && !bidx.has(ai)) {
-      // replace
-      if (bj && !aidx.has(bj)) parent.replaceChild(bj, ai)
-
-      // remove
-      else (parent.removeChild(ai), j--)
+    // remove
+    else if (cur && !bidx.has(cur)) {
+      parent.removeChild(cur), i--, cur = next
     }
-    else if (bj) {
-      // move - skips bj for the following swap
-      if (!aidx.has(bj)) i--
+    else if (bi) {
+      // swap (only 1:1 pairs)
+      if (aidx.has(bi) && b[i+1] === next) {
+        parent.insertBefore(cur, bi), cur = next
+      }
 
-      // insert after bj-1, bj
-      parent.insertBefore(bj, bprevNext)
+      // insert after bi-1, bi
+      parent.insertBefore(bi, cur)
     }
-
-    bprevNext = bj && bj.nextSibling
   }
 
   return b

--- a/libs/spect.js
+++ b/libs/spect.js
@@ -3,21 +3,17 @@ module.exports = function merge (parent, a, b) {
   let i, cur = a[0], next, bi
 
   for (i = 0; i <= b.length; i++) {
-    bi = b[i]
-    next = cur && cur.nextSibling
+    bi = b[i], next = cur && cur.nextSibling
 
     // skip
     if (cur === bi) cur = next
 
     // remove
-    else if (cur && !bidx.has(cur)) {
-      parent.removeChild(cur), i--, cur = next
-    }
+    else if (cur && !bidx.has(cur)) (parent.removeChild(cur), i--, cur = next)
+
     else if (bi) {
-      // swap (only 1:1 pairs)
-      if (aidx.has(bi) && b[i+1] === next) {
-        parent.insertBefore(cur, bi), cur = next
-      }
+      // swap (only 1:1 pairs) (technically redundant but avoids long rearrangements)
+      if (aidx.has(bi) && b[i+1] === next) (parent.insertBefore(cur, bi), cur = next)
 
       // insert after bi-1, bi
       parent.insertBefore(bi, cur)


### PR DESCRIPTION
Ok, [hopefully] the latest spect implementation, 209b.
This version allows passing live `parent.childNodes` collection as `a` (no need for slicing), so `a` is optional. Also that doesn't need `before`, because that's forward algorithm.
Also the digits seem to be better now.
![image](https://user-images.githubusercontent.com/300067/79657182-0e5d9600-8181-11ea-8057-24c9b3d571e3.png)
