### PR TITLE
Add tail-skip

### DIFF
--- a/libs/spect.js
+++ b/libs/spect.js
@@ -1,31 +1,34 @@
 module.exports = (parent, a, b, end = null) => {
-  let i = 0, cur, next, bi
+  let i = 0, cur, next, bi, n = b.length, dif = n - a.length
 
   // skip head
-  while (a[i] === b[i] && b[i++]);
+  while (a[i] === b[i] && i++ < n);
 
-  // append
-  if (i == a.length) while (bi = b[i++]) parent.insertBefore(bi, end)
+  // skip tail
+  while (--n >= dif && b[n] === a[n - dif]) end = b[n];
+
+  // append/prepend shortcut
+  if (i > n - dif) while (i <= n) parent.insertBefore(b[i++], end)
 
   else {
-    cur = a[i] || end
-
-    while (bi = b[i++]) {
-      next = cur ? cur.nextSibling : end
+    cur = a[i]
+    while (i <= n) {
+      bi = b[i++], next = cur ? cur.nextSibling : end
 
       // skip
       if (cur == bi) cur = next
 
       // swap / replace
-      else if (b[i] === next) (parent.replaceChild(bi, cur), cur = next)
+      else if (i < n && b[i] === next) (parent.replaceChild(bi, cur), cur = next)
 
       // insert
       else parent.insertBefore(bi, cur)
     }
 
     // remove tail
-    while (cur !== end) (next = cur ? cur.nextSibling : end, parent.removeChild(cur), cur = next)
+    while (cur !== end) (next = cur.nextSibling, parent.removeChild(cur), cur = next)
   }
 
   return b
 }
+


### PR DESCRIPTION
With considerations from #35 (safe array access), also with added tail-skip.
It bumps from 208 → 248 bytes, but makes prepend faster.