### PR TITLE
Spect 260

### DIFF
--- a/libs/spect.js
+++ b/libs/spect.js
@@ -5,29 +5,32 @@ module.exports = (parent, a, b, end = null) => {
   while (i < n && i < m && a[i] == b[i]) i++
   while (i < n && i < m && b[n-1] == a[m-1]) end = b[--m, --n]
 
-  // append/prepend/clear shortcuts
-  if (i == m) { while (i < n) parent.insertBefore(b[i++], end); return b }
-  if (i == n) { while (i < m) parent.removeChild(a[i++]); return b }
+  // append/prepend/trim shortcuts
+  if (i == m) while (i < n) parent.insertBefore(b[i++], end)
+  if (i == n) while (i < m) parent.removeChild(a[i++])
 
-  cur = a[i]
+  else {
+    cur = a[i]
 
-  while (i < n) {
-    bi = b[i++], next = cur ? cur.nextSibling : end
+    while (i < n) {
+      bi = b[i++], next = cur ? cur.nextSibling : end
 
-    // skip
-    if (cur == bi) cur = next
+      // skip
+      if (cur == bi) cur = next
 
-    // swap / replace
-    else if (i < n && b[i] == next) (parent.replaceChild(bi, cur), cur = next)
+      // swap / replace
+      else if (i < n && b[i] == next) (parent.replaceChild(bi, cur), cur = next)
 
-    // insert
-    else parent.insertBefore(bi, cur)
+      // insert
+      else parent.insertBefore(bi, cur)
+    }
+
+    // remove tail
+    while (cur != end) (next = cur.nextSibling, parent.removeChild(cur), cur = next)
   }
-
-  // remove tail
-  while (cur != end) (next = cur.nextSibling, parent.removeChild(cur), cur = next)
 
   return b
 }
+
 
 

--- a/libs/spect.js
+++ b/libs/spect.js
@@ -1,35 +1,33 @@
 module.exports = (parent, a, b, end = null) => {
   let i = 0, cur, next, bi, n = b.length, m = a.length
 
-  // skip head
+  // skip head/tail
   while (i < n && i < m && a[i] == b[i]) i++
+  while (i < n && i < m && b[n-1] == a[m-1]) end = b[--m, --n]
 
-  // skip tail
-  while (n && m && b[n-1] == a[m-1]) end = b[--m, --n]
+  // append/prepend/clear shortcuts
+  if (i == m) { while (i < n) parent.insertBefore(b[i++], end); return b }
+  if (i == n) { while (i < m) parent.removeChild(a[i++]); return b }
 
-  // append/prepend shortcut
-  if (i == m) while (i < n) parent.insertBefore(b[i++], end)
+  cur = a[i]
 
-  else {
-    cur = a[i]
-    
-    while (i < n) {
-      bi = b[i++], next = cur ? cur.nextSibling : end
+  while (i < n) {
+    bi = b[i++], next = cur ? cur.nextSibling : end
 
-      // skip
-      if (cur == bi) cur = next
+    // skip
+    if (cur == bi) cur = next
 
-      // swap / replace
-      else if (i < n && b[i] == next) (parent.replaceChild(bi, cur), cur = next)
+    // swap / replace
+    else if (i < n && b[i] == next) (parent.replaceChild(bi, cur), cur = next)
 
-      // insert
-      else parent.insertBefore(bi, cur)
-    }
-
-    // remove tail
-    while (cur != end) (next = cur.nextSibling, parent.removeChild(cur), cur = next)
+    // insert
+    else parent.insertBefore(bi, cur)
   }
+
+  // remove tail
+  while (cur != end) (next = cur.nextSibling, parent.removeChild(cur), cur = next)
 
   return b
 }
+
 


### PR DESCRIPTION
- clear/trim shortcut
- fixed tail skipping overshoot on identical input/output arrays
- size bumped to 260 (+8b)